### PR TITLE
Quivers can be used as baubles

### DIFF
--- a/src/main/java/cofh/thermalinnovation/item/ItemQuiver.java
+++ b/src/main/java/cofh/thermalinnovation/item/ItemQuiver.java
@@ -1,5 +1,7 @@
 package cofh.thermalinnovation.item;
 
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
 import cofh.api.item.IToolQuiver;
 import cofh.core.init.CoreEnchantments;
 import cofh.core.init.CoreProps;
@@ -42,7 +44,7 @@ import java.util.Map;
 import static cofh.core.util.helpers.RecipeHelper.*;
 import static cofh.thermalfoundation.util.TFCrafting.addPotionFillRecipe;
 
-public class ItemQuiver extends ItemMultiPotion implements IInitializer, IToolQuiver {
+public class ItemQuiver extends ItemMultiPotion implements IInitializer, IToolQuiver, IBaubleItem {
 
 	public ItemQuiver() {
 
@@ -462,6 +464,17 @@ public class ItemQuiver extends ItemMultiPotion implements IInitializer, IToolQu
 		for (int i = 0; i < CAPACITY_FLUID.length; i++) {
 			CAPACITY_FLUID[i] *= capacity;
 		}
+	}
+
+	/* IBauble */
+	@override
+	public BaubleType getBaubleType(ItemStack itemstack) {
+		return BaubleType.BODY;
+	}
+
+	@override
+	public default boolean willAutoSync(ItemStack itemstack, EntityLivingBase player) {
+		return true;
 	}
 
 	/* ENTRY */


### PR DESCRIPTION
This PR makes Quivers usable in the Body Baubles slot.
There's another PR to CoFHCore to make it so arrows will be extracted when the Quiver is used as a bauble: https://github.com/CoFH/CoFHCore/pull/65